### PR TITLE
TEL-10 Implement multi-tenant telemetry data storage and API

### DIFF
--- a/src/main/java/dev/bencsik/telescope/controller/TelemetryController.java
+++ b/src/main/java/dev/bencsik/telescope/controller/TelemetryController.java
@@ -1,0 +1,29 @@
+package dev.bencsik.telescope.controller;
+
+import dev.bencsik.telescope.model.TelemetryData;
+import dev.bencsik.telescope.repository.TelemetryRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/telemetry")
+public class TelemetryController {
+
+    private final TelemetryRepository telemetryRepository;
+
+    public TelemetryController(TelemetryRepository telemetryRepository) {
+        this.telemetryRepository = telemetryRepository;
+    }
+
+    @PostMapping
+    public TelemetryData storeTelemetry(@RequestBody TelemetryData telemetryData) {
+        System.out.println("Received JSON: " + telemetryData);  // Debugging log
+        return telemetryRepository.save(telemetryData);
+    }
+
+    @GetMapping
+    public List<TelemetryData> getTelemetryData() {
+        return telemetryRepository.findAll();
+    }
+}

--- a/src/main/java/dev/bencsik/telescope/model/TelemetryData.java
+++ b/src/main/java/dev/bencsik/telescope/model/TelemetryData.java
@@ -1,0 +1,73 @@
+package dev.bencsik.telescope.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "telemetry_data")
+public class TelemetryData {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    private LocalDateTime timestamp;
+
+    @Column(name = "metric_name", nullable = false)
+    @JsonProperty("metricName")
+    private String metricName;
+
+    @Column(nullable = false)
+    private double value;
+
+    @PrePersist
+    protected void onCreate() {
+        this.timestamp = LocalDateTime.now();
+    }
+
+    // Debugging
+    @Override
+    public String toString() {
+        return "TelemetryData{" +
+                "id=" + id +
+                ", timestamp=" + timestamp +
+                ", metricName='" + metricName + '\'' +
+                ", value=" + value +
+                '}';
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getMetricName() {
+        return metricName;
+    }
+
+    public void setMetricName(String metricName) {
+        this.metricName = metricName;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/dev/bencsik/telescope/repository/TelemetryRepository.java
+++ b/src/main/java/dev/bencsik/telescope/repository/TelemetryRepository.java
@@ -1,0 +1,11 @@
+package dev.bencsik.telescope.repository;
+
+import dev.bencsik.telescope.model.TelemetryData;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface TelemetryRepository extends JpaRepository<TelemetryData, UUID> {
+}

--- a/src/main/resources/db/migration/V3__Create_telemetry_table.sql
+++ b/src/main/resources/db/migration/V3__Create_telemetry_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS telemetry_data (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMP DEFAULT NOW(),
+    metric_name VARCHAR(255) NOT NULL,
+    value DOUBLE PRECISION NOT NULL
+);


### PR DESCRIPTION
- Added Flyway migration for `telemetry_data` table.
- Created `TelemetryData` JPA entity for metric storage.
- Implemented `TelemetryRepository` for CRUD operations.
- Developed `TelemetryController` with endpoints for storing & retrieving telemetry.
- Verified API functionality with tenant-based schema switching.