### PR TITLE
TELE-15 Deploy Telemetry API to AWS EKS

### DIFF
--- a/kubernetes/aws-auth-patch.yaml
+++ b/kubernetes/aws-auth-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+data:
+  mapUsers: |
+    - userarn: arn:aws:iam::353009653875:user/telemetry-admin
+      username: telemetry-admin
+      groups:
+        - system:masters

--- a/kubernetes/cluster-admin.yaml
+++ b/kubernetes/cluster-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: telemetry-admin-binding
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: User
+    name: arn:aws:iam::353009653875:user/telemetry-admin
+    apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/database.yaml
+++ b/kubernetes/database.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telemetry-db
+  namespace: database
+  labels:
+    app: telemetry-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: telemetry-db
+  template:
+    metadata:
+      labels:
+        app: telemetry-db
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:14
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: "multi_tenant_db"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              value: "mypassword"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: telemetry-db
+  namespace: database
+spec:
+  selector:
+    app: telemetry-db
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+  clusterIP: None

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telemetry-api
+  labels:
+    app: telemetry-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: telemetry-api
+  template:
+    metadata:
+      labels:
+        app: telemetry-api
+    spec:
+      containers:
+        - name: telemetry-api
+          image: 353009653875.dkr.ecr.eu-central-1.amazonaws.com/telemetry-api:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_DATASOURCE_URL
+              value: "jdbc:postgresql://telemetry-db.database.svc.cluster.local:5432/multi_tenant_db"
+            - name: SPRING_DATASOURCE_USERNAME
+              value: "postgres"
+            - name: SPRING_DATASOURCE_PASSWORD
+              value: "mypassword"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: telemetry-api-service
+spec:
+  selector:
+    app: telemetry-api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: LoadBalancer


### PR DESCRIPTION
- Created .yaml files for deployment.
- The telemetry API is now working on AWS EKS.
- Created api.bencsik.dev record to access the load balancer endpoint.
- Changed the DNS namespaces, so AWS manages the bencsik.dev DNS from now on.
- Tested the deployed application with key generation, data retrieval.